### PR TITLE
docs: fix README to accurately reflect API capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ N8N Community Node for the [Deep-OCR Service](https://deep-ocr.com) - Extract st
 
 ## 🚀 Features
 
-- **Structured Data Extraction**: Receive a typed JSON object with the fields relevant to the document type
+- **Structured Data Extraction**: Receive a structured JSON object with the fields relevant to the document type
 - **7 Document Types**: Invoice, Receipt, Contract, Delivery Note, ID Document, Handwriting, Generic
 - **Multiple Format Support**: PDF, PNG, JPG, JPEG, WebP (up to 10MB)
 - **Secure Authentication**: API key stored securely using n8n credentials


### PR DESCRIPTION
## Summary

- Remove inaccurate "Full Text Extraction" feature claim (API only returns structured JSON)
- Remove non-existent `Output Format` and `Fields` parameters from usage docs
- Add document type reference table
- Fix Node.js version requirement (22+)
- Remove spec-kit reference