### PR TITLE
ci: add concurrency group to cancel stacked CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build & Test


### PR DESCRIPTION
## Summary

- Adds a `concurrency` group to `.github/workflows/ci.yml`
- `cancel-in-progress: true` — stale runs are cancelled when a new commit is pushed

## Why

Without this, every push to `main` and every new commit on a PR started a fresh run alongside still-running older ones, wasting Actions minutes on outdated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)