### PR TITLE
chore: sync package.json and dist to v1.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-deep-ocr",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "n8n community node for Deep-OCR document processing API",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Automated sync after npm release v1.5.15.

- Updates `package.json` version to match the published npm version
- Rebuilds `dist/` from the release tag so the repo stays current

Required for n8n submission vetting (checks both repo version and credential file).